### PR TITLE
Update nodejs plan

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -1,5 +1,5 @@
 #include <turnkey/base>
-#include <turnkey/nodejs>
+#include <turnkey/nodejs-nginx>
 
 ca-certificates
 python3-pymongo


### PR DESCRIPTION
Update nodejs plan (old `nodejs` plan no longer has nginx).

Part of https://github.com/turnkeylinux/tracker/issues/1772

Also requires:

- https://github.com/turnkeylinux/common/pull/231
- https://github.com/turnkeylinux-apps/etherpad/pull/18
- https://github.com/turnkeylinux-apps/ghost/pull/16
- https://github.com/turnkeylinux-apps/nodejs/pull/15
- https://github.com/turnkeylinux-apps/redis/pull/8